### PR TITLE
#3 [enhance] OCRBench v2 선택적 의존성 추가

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,15 @@ prismmbench = [
     "pdf2image>=1.17.0",
     "pdfplumber>=0.11.9"
 ]
+ocrbench = [
+    "jieba",
+    "distance",
+    "editdistance",
+    "python-Levenshtein",
+    "apted",
+    "lxml",
+    "Polygon3",
+]
 tui = [
     "fastapi>=0.100.0",
     "uvicorn>=0.20.0",


### PR DESCRIPTION
<!--
PR 작성 전 한 번씩 읽어주세요.

# How to write Good Commit Message
# 1. Specify the type of commit: feat, enh, bugfix, style, docs
# 2. Separate the subject from the body with a blank line
# 3. Your commit message should not contain any whitespace errors
# 4. Remove unnecessary punctuation marks
# 5. Do not end the subject line with a period
# 6. Capitalize the subject line and each paragraph
# 7. Use the imperative mood in the subject line
# 8. Use the body to explain what changes you have made and why you made them.
# 9. Do not assume the reviewer understands what the original problem was, ensure you add it.
# 10. Do not think your code is self-explanatory
# 11. Follow the commit convention defined by your team
-->

## Issue?
#3

## Changes?
`pyproject.toml`에 `ocrbench` 선택적 의존성 그룹을 추가했습니다.

포함된 패키지:
- `jieba` — 중국어 텍스트 분할 (page_ocr_metric)
- `distance`, `editdistance`, `python-Levenshtein` — 문자열 유사도 메트릭
- `apted` — 트리 편집 거리 연산
- `lxml` — XML/HTML 파싱
- `Polygon3` — 기하학적 연산 (spotting_metric)

## Why we need?
OCRBench v2 평가 실행 시 위 패키지들이 설치되어 있지 않으면 `ModuleNotFoundError`가 발생합니다. 선택적 의존성 그룹으로 정의하여 `uv sync --extra ocrbench` 명령으로 간편하게 설치할 수 있도록 합니다.

## Test?
- `uv sync --extra ocrbench` 실행 후 OCRBench v2 평가가 정상 동작하는 것을 확인

## CC (Optional)

## Anything else? (Optional)
NLTK 데이터(`punkt`, `punkt_tab`, `wordnet`)는 패키지 매니저로 관리할 수 없으며, 별도 다운로드가 필요합니다:
```bash
python -c "import nltk; nltk.download('punkt'); nltk.download('punkt_tab'); nltk.download('wordnet')"
```

Made with [Cursor](https://cursor.com)