### PR TITLE
feat: add ChartQA and Benetech chart parsing benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ remote_code/*
 docs/plans/
 .opencode
 .worktrees/
+results/

--- a/lmms_eval/tasks/benetech/benetech_parsing.yaml
+++ b/lmms_eval/tasks/benetech/benetech_parsing.yaml
@@ -1,0 +1,41 @@
+dataset_path: parquet
+dataset_kwargs:
+  data_files:
+    test: /data/workspace/hongcheol/lmms-eval/data/benetech_parsing/test.parquet
+task: "benetech_parsing"
+test_split: test
+output_type: generate_until
+doc_to_visual: !function utils.benetech_doc_to_visual
+doc_to_text: !function utils.benetech_doc_to_text
+doc_to_target: "data_series_json"
+generation_kwargs:
+  max_new_tokens: 2048
+  temperature: 0
+  do_sample: False
+process_results: !function utils.benetech_process_results
+metric_list:
+  - metric: benetech_overall
+    aggregation: mean
+    higher_is_better: true
+  - metric: benetech_ocr
+    aggregation: mean
+    higher_is_better: true
+  - metric: benetech_value
+    aggregation: mean
+    higher_is_better: true
+  - metric: benetech_type_acc
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  - version: 0.0
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: |
+      Extract the chart type and all data points from this chart image.
+      Return a JSON object with this exact format:
+      {"chart_type": "<type>", "data_series": [{"x": <value>, "y": <value>}, ...]}
+      where chart_type is one of: line, vertical_bar, horizontal_bar, scatter, dot.
+      For x values, use strings for categorical labels and numbers for numeric axes.
+      For y values, use numbers.
+      Return ONLY the JSON object, no other text.

--- a/lmms_eval/tasks/benetech/upload_benetech_parsing.py
+++ b/lmms_eval/tasks/benetech/upload_benetech_parsing.py
@@ -1,0 +1,138 @@
+"""
+Benetech Parsing 데이터셋 준비 스크립트
+
+Benetech "Making Graphs Accessible" 대회 데이터에서 source=extracted만 추출하여
+lmms-eval용 parquet 데이터셋으로 변환.
+
+각 차트 이미지에 대응하는 GT annotation을 포함:
+  - image: 차트 이미지
+  - image_id: 이미지 파일명 (확장자 제외)
+  - chart_type: 차트 유형 (line, vertical_bar, scatter, dot, horizontal_bar)
+  - data_series_json: GT data-series JSON 문자열 ([{"x": ..., "y": ...}, ...])
+  - num_points: 데이터 포인트 수
+
+Usage:
+    python upload_benetech_parsing.py
+"""
+
+import json
+import os
+
+import datasets
+from PIL import Image
+
+BENETECH_ROOT = "/data/workspace/hongcheol/thaki-document-understanding/data/benetech/train"
+
+_CITATION = """\
+@misc{benetech2023,
+    title = {Benetech - Making Graphs Accessible},
+    year = {2023},
+    url = {https://www.kaggle.com/competitions/benetech-making-graphs-accessible},
+}
+"""
+
+_DESCRIPTION = "Benetech Parsing: chart image to structured data series extraction benchmark (extracted subset only)."
+
+
+dataset_features = {
+    "image": datasets.Image(),
+    "image_id": datasets.Value("string"),
+    "chart_type": datasets.Value("string"),
+    "data_series_json": datasets.Value("string"),
+    "num_points": datasets.Value("int32"),
+}
+
+
+def generate_extracted_split(ann_dir: str, image_dir: str):
+    """source=extracted인 annotation만 필터링하여 데이터셋 생성."""
+    index = 0
+    for ann_file in sorted(os.listdir(ann_dir)):
+        if not ann_file.endswith(".json"):
+            continue
+
+        ann_path = os.path.join(ann_dir, ann_file)
+        with open(ann_path, encoding="utf-8") as f:
+            ann = json.load(f)
+
+        if ann.get("source") != "extracted":
+            continue
+
+        image_id = ann_file.replace(".json", "")
+        image_path = os.path.join(image_dir, f"{image_id}.jpg")
+        if not os.path.exists(image_path):
+            continue
+
+        data_series = ann.get("data-series", [])
+        chart_type = ann.get("chart-type", "unknown")
+
+        yield index, {
+            "image": Image.open(image_path).convert("RGB"),
+            "image_id": image_id,
+            "chart_type": chart_type,
+            "data_series_json": json.dumps(data_series, ensure_ascii=False),
+            "num_points": len(data_series),
+        }
+        index += 1
+
+
+class BenetechParsing(datasets.GeneratorBasedBuilder):
+    VERSION = datasets.Version("1.0.0")
+
+    BUILDER_CONFIGS = [
+        datasets.BuilderConfig(
+            name="BenetechParsing",
+            version=datasets.Version("1.0.0"),
+            description="Benetech Parsing benchmark (extracted only)",
+        )
+    ]
+
+    def _info(self):
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=datasets.Features(dataset_features),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "ann_dir": os.path.join(BENETECH_ROOT, "annotations"),
+                    "image_dir": os.path.join(BENETECH_ROOT, "images"),
+                },
+            ),
+        ]
+
+    def _generate_examples(self, ann_dir, image_dir):
+        yield from generate_extracted_split(ann_dir, image_dir)
+
+
+if __name__ == "__main__":
+    import datasets as ds
+
+    ann_dir = os.path.join(BENETECH_ROOT, "annotations")
+    image_dir = os.path.join(BENETECH_ROOT, "images")
+
+    rows = []
+    for idx, row in generate_extracted_split(ann_dir, image_dir):
+        rows.append(row)
+        if idx % 100 == 0:
+            print(f"  Processed {idx + 1} samples...")
+
+    print(f"\nTotal extracted samples: {len(rows)}")
+
+    data = ds.Dataset.from_dict(
+        {k: [r[k] for r in rows] for k in dataset_features.keys()},
+        features=ds.Features(dataset_features),
+    )
+    print(data)
+    print(f"Sample chart_type: {data[0]['chart_type']}")
+    print(f"Sample num_points: {data[0]['num_points']}")
+
+    script_path = os.path.abspath(__file__)
+    output_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(script_path)))), "data", "benetech_parsing")
+    os.makedirs(output_dir, exist_ok=True)
+    output_path = os.path.join(output_dir, "test.parquet")
+    data.to_parquet(output_path)
+    print(f"\nSaved to: {output_path}")

--- a/lmms_eval/tasks/benetech/utils.py
+++ b/lmms_eval/tasks/benetech/utils.py
@@ -1,0 +1,180 @@
+"""
+Benetech Parsing 태스크 유틸리티
+
+Benetech "Making Graphs Accessible" 공식 메트릭 기반 평가.
+  - chart_type 불일치 -> x, y 모두 0점
+  - 값 개수 불일치 -> 해당 시리즈 0점
+  - 숫자 시리즈 -> sigmoid(sqrt(1 - R2))
+  - 문자열 시리즈 -> sigmoid(total_levenshtein / total_len)
+  - 최종 점수 -> 모든 시리즈 점수의 평균
+
+Reference:
+  https://www.kaggle.com/competitions/benetech-making-graphs-accessible/overview/evaluation
+"""
+
+import json
+import re
+from typing import Optional
+
+import numpy as np
+from rapidfuzz.distance.Levenshtein import distance as levenshtein_distance
+from sklearn.metrics import r2_score
+
+# ---------------------------------------------------------------------------
+# Benetech 공식 메트릭 핵심 함수
+# ---------------------------------------------------------------------------
+
+
+def _sigmoid(x: float) -> float:
+    return 2 - 2 / (1 + np.exp(-x))
+
+
+def _normalized_rmse(y_true: list, y_pred: list) -> float:
+    y_true = np.array(y_true, dtype=np.float64)
+    y_pred = np.array(y_pred, dtype=np.float64)
+    valid = np.isfinite(y_true) & np.isfinite(y_pred)
+    if valid.sum() < 2:
+        return 0.0
+    y_true, y_pred = y_true[valid], y_pred[valid]
+    return float(_sigmoid((1 - r2_score(y_true, y_pred)) ** 0.5))
+
+
+def _normalized_levenshtein(y_true: list, y_pred: list) -> float:
+    total_dist = sum(levenshtein_distance(str(yt), str(yp)) for yt, yp in zip(y_true, y_pred))
+    total_len = sum(len(str(yt)) for yt in y_true)
+    if total_len == 0:
+        return 0.0
+    return float(_sigmoid(total_dist / total_len))
+
+
+def _score_series(y_true: list, y_pred: list) -> float:
+    """단일 시리즈 (x 또는 y) 점수. 길이 불일치 -> 0점."""
+    if len(y_true) != len(y_pred) or len(y_true) == 0:
+        return 0.0
+
+    if isinstance(y_true[0], str):
+        return _normalized_levenshtein(y_true, [str(x) for x in y_pred])
+    else:
+        try:
+            y_pred_num = [float(x) for x in y_pred]
+        except (ValueError, TypeError):
+            return 0.0
+        return _normalized_rmse(y_true, y_pred_num)
+
+
+def _is_str_series(series: list) -> bool:
+    return len(series) > 0 and isinstance(series[0], str)
+
+
+# ---------------------------------------------------------------------------
+# JSON 파싱 헬퍼
+# ---------------------------------------------------------------------------
+
+
+def _extract_json(text: str) -> Optional[dict]:
+    """모델 출력에서 JSON 객체를 추출. 코드 블록 안이나 직접 JSON 모두 처리."""
+    code_block = re.search(r"```(?:json)?\s*\n(.*?)\n```", text, re.DOTALL)
+    if code_block:
+        text = code_block.group(1).strip()
+
+    for start in range(len(text)):
+        if text[start] == "{":
+            for end in range(len(text), start, -1):
+                if text[end - 1] == "}":
+                    try:
+                        return json.loads(text[start:end])
+                    except json.JSONDecodeError:
+                        continue
+    return None
+
+
+def _load_pred_series(pred: dict) -> tuple:
+    """예측 JSON에서 (x_series, y_series, chart_type) 추출."""
+    chart_type = pred.get("chart_type", "unknown")
+    ds = pred.get("data_series", [])
+    if not isinstance(ds, list):
+        return [], [], chart_type
+
+    pred_x, pred_y = [], []
+    for dp in ds:
+        if isinstance(dp, dict):
+            pred_x.append(dp.get("x", ""))
+            pred_y.append(dp.get("y", ""))
+        else:
+            return [], [], chart_type
+    return pred_x, pred_y, chart_type
+
+
+def _load_gt_series(data_series: list) -> tuple:
+    """GT data-series에서 (x_values, y_values) 추출. 원래 타입 유지."""
+    gt_x = [dp["x"] for dp in data_series]
+    gt_y = [dp["y"] for dp in data_series]
+    return gt_x, gt_y
+
+
+# ---------------------------------------------------------------------------
+# lmms-eval 태스크 인터페이스
+# ---------------------------------------------------------------------------
+
+
+def benetech_doc_to_visual(doc):
+    return [doc["image"].convert("RGB")]
+
+
+def benetech_doc_to_text(doc, lmms_eval_specific_kwargs):
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "")
+    return f"{pre_prompt}{post_prompt}"
+
+
+def benetech_process_results(doc, results):
+    pred_text = results[0]
+    gt_chart_type = doc["chart_type"]
+    gt_data_series = json.loads(doc["data_series_json"])
+    gt_x, gt_y = _load_gt_series(gt_data_series)
+
+    zero = {
+        "benetech_overall": 0.0,
+        "benetech_ocr": 0.0,
+        "benetech_value": 0.0,
+        "benetech_type_acc": 0.0,
+    }
+
+    pred_obj = _extract_json(pred_text)
+    if pred_obj is None:
+        return zero
+
+    pred_x, pred_y, pred_chart_type = _load_pred_series(pred_obj)
+
+    chart_type_match = gt_chart_type == pred_chart_type
+    type_acc = 1.0 if chart_type_match else 0.0
+
+    if chart_type_match:
+        x_score = _score_series(gt_x, pred_x)
+        y_score = _score_series(gt_y, pred_y)
+    else:
+        x_score = 0.0
+        y_score = 0.0
+
+    overall = (x_score + y_score) / 2
+
+    x_is_str = _is_str_series(gt_x)
+    y_is_str = _is_str_series(gt_y)
+
+    ocr_scores = []
+    value_scores = []
+    for score, is_str in [(x_score, x_is_str), (y_score, y_is_str)]:
+        if is_str:
+            ocr_scores.append(score)
+        else:
+            value_scores.append(score)
+
+    ocr_mean = float(np.mean(ocr_scores)) if ocr_scores else overall
+    value_mean = float(np.mean(value_scores)) if value_scores else overall
+
+    return {
+        "benetech_overall": overall,
+        "benetech_ocr": ocr_mean,
+        "benetech_value": value_mean,
+        "benetech_type_acc": type_acc,
+    }

--- a/lmms_eval/tasks/chartqa/chartqa_parsing.yaml
+++ b/lmms_eval/tasks/chartqa/chartqa_parsing.yaml
@@ -1,0 +1,40 @@
+dataset_path: parquet
+dataset_kwargs:
+  data_files:
+    test: /data/workspace/hongcheol/lmms-eval/data/chartqa_parsing/test.parquet
+task: "chartqa_parsing"
+test_split: test
+output_type: generate_until
+doc_to_visual: !function utils.chartqa_parsing_doc_to_visual
+doc_to_text: !function utils.chartqa_parsing_doc_to_text
+doc_to_target: "table_csv"
+generation_kwargs:
+  max_new_tokens: 1024
+  temperature: 0
+  do_sample: False
+process_results: !function utils.chartqa_parsing_process_results
+metric_list:
+  - metric: parsing_overall
+    aggregation: mean
+    higher_is_better: true
+  - metric: parsing_label
+    aggregation: mean
+    higher_is_better: true
+  - metric: parsing_value
+    aggregation: mean
+    higher_is_better: true
+  - metric: robust_overall
+    aggregation: mean
+    higher_is_better: true
+  - metric: robust_label
+    aggregation: mean
+    higher_is_better: true
+  - metric: robust_value
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  - version: 0.0
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "Extract all data from this chart as a markdown table."

--- a/lmms_eval/tasks/chartqa/upload_chartqa_parsing.py
+++ b/lmms_eval/tasks/chartqa/upload_chartqa_parsing.py
@@ -1,0 +1,133 @@
+"""
+ChartQA Parsing 데이터셋 업로드 스크립트
+
+차트 이미지 + GT 테이블(CSV)을 HuggingFace 데이터셋으로 변환.
+기존 ChartQA의 QA 데이터가 아닌, 차트 파싱 평가용 데이터셋.
+
+각 차트 이미지에 대응하는 CSV 테이블을 GT로 포함:
+  - image: 차트 이미지
+  - image_id: 이미지 파일명 (확장자 제외)
+  - table_csv: GT 테이블 원문 (CSV 문자열)
+  - num_columns: 컬럼 수
+  - num_rows: 데이터 행 수 (헤더 제외)
+
+Usage:
+    python upload_chartqa_parsing.py
+"""
+
+import csv
+import io
+import os
+
+import datasets
+from PIL import Image
+
+CHARTQA_ROOT = "/data/workspace/hongcheol/ChartQA/ChartQA Dataset"
+
+_CITATION = """\
+@inproceedings{masry-etal-2022-chartqa,
+    title = "{C}hart{QA}: A Benchmark for Question Answering about Charts with Visual and Logical Reasoning",
+    author = "Masry, Ahmed  and Long, Do  and Tan, Jia Qing  and Joty, Shafiq  and Hoque, Enamul",
+    booktitle = "Findings of the Association for Computational Linguistics: ACL 2022",
+    year = "2022",
+    url = "https://aclanthology.org/2022.findings-acl.177",
+    pages = "2263--2279",
+}
+"""
+
+_DESCRIPTION = "ChartQA Parsing: chart image to underlying data table extraction benchmark."
+
+
+dataset_features = {
+    "image": datasets.Image(),
+    "image_id": datasets.Value("string"),
+    "table_csv": datasets.Value("string"),
+    "num_columns": datasets.Value("int32"),
+    "num_rows": datasets.Value("int32"),
+}
+
+
+def read_csv_info(csv_path):
+    """CSV 파일을 읽어서 원문 문자열, 컬럼 수, 행 수를 반환."""
+    with open(csv_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    reader = csv.reader(io.StringIO(content))
+    rows = list(reader)
+    if len(rows) == 0:
+        return content, 0, 0
+    num_columns = len(rows[0])
+    num_rows = len(rows) - 1  # 헤더 제외
+    return content, num_columns, num_rows
+
+
+def generate_split(image_dir, table_dir):
+    """이미지와 테이블을 매칭하여 데이터셋 생성."""
+    table_files = {f.replace(".csv", ""): os.path.join(table_dir, f) for f in os.listdir(table_dir) if f.endswith(".csv")}
+
+    index = 0
+    for img_file in sorted(os.listdir(image_dir)):
+        if not img_file.endswith(".png"):
+            continue
+        image_id = img_file.replace(".png", "")
+        if image_id not in table_files:
+            continue
+
+        image_path = os.path.join(image_dir, img_file)
+        csv_path = table_files[image_id]
+        table_csv, num_columns, num_rows = read_csv_info(csv_path)
+
+        yield index, {
+            "image": Image.open(image_path).convert("RGB"),
+            "image_id": image_id,
+            "table_csv": table_csv,
+            "num_columns": num_columns,
+            "num_rows": num_rows,
+        }
+        index += 1
+
+
+class ChartQAParsing(datasets.GeneratorBasedBuilder):
+    VERSION = datasets.Version("1.0.0")
+
+    BUILDER_CONFIGS = [
+        datasets.BuilderConfig(
+            name="ChartQAParsing",
+            version=datasets.Version("1.0.0"),
+            description="ChartQA Parsing benchmark",
+        )
+    ]
+
+    def _info(self):
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=datasets.Features(dataset_features),
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "image_dir": os.path.join(CHARTQA_ROOT, "test", "png"),
+                    "table_dir": os.path.join(CHARTQA_ROOT, "test", "tables"),
+                },
+            ),
+        ]
+
+    def _generate_examples(self, image_dir, table_dir):
+        yield from generate_split(image_dir, table_dir)
+
+
+if __name__ == "__main__":
+    from datasets import load_dataset
+
+    script_path = os.path.abspath(__file__)
+    data = load_dataset(script_path)
+    print(data)
+    print(f"\nTest set size: {len(data['test'])}")
+    print(f"Sample: {data['test'][0]}")
+
+    # HuggingFace Hub에 업로드하려면 아래 주석 해제
+    # data.push_to_hub("your-org/chartqa-parsing", private=True)

--- a/lmms_eval/tasks/chartqa/utils.py
+++ b/lmms_eval/tasks/chartqa/utils.py
@@ -1,3 +1,12 @@
+import csv
+import io
+import re
+
+import numpy as np
+from rapidfuzz.distance.Levenshtein import distance as levenshtein_distance
+from sklearn.metrics import r2_score
+
+
 def chartqa_doc_to_visual(doc):
     return [doc["image"].convert("RGB")]
 
@@ -60,3 +69,365 @@ def relaxed_correctness(prediction, target, max_relative_change: float = 0.05) -
         return relative_change <= max_relative_change
     else:
         return prediction.lower() == target.lower()
+
+
+# ---------------------------------------------------------------------------
+# Chart Parsing: Benetech 확장 메트릭
+# ---------------------------------------------------------------------------
+
+
+def _sigmoid(x: float) -> float:
+    """Benetech 공식 sigmoid: 점수를 0~1 범위로 매핑."""
+    return 2 - 2 / (1 + np.exp(-x))
+
+
+def _normalized_rmse(y_true: list, y_pred: list) -> float:
+    """숫자 시리즈 점수. sigmoid(sqrt(1 - R²))"""
+    y_true = np.array(y_true, dtype=np.float64)
+    y_pred = np.array(y_pred, dtype=np.float64)
+
+    valid = np.isfinite(y_true) & np.isfinite(y_pred)
+    if valid.sum() < 2:
+        return 0.0
+    y_true, y_pred = y_true[valid], y_pred[valid]
+
+    return float(_sigmoid((1 - r2_score(y_true, y_pred)) ** 0.5))
+
+
+def _normalized_levenshtein(y_true: list, y_pred: list) -> float:
+    """문자열 시리즈 점수. sigmoid(total_dist / total_len)"""
+    total_dist = sum(levenshtein_distance(str(yt), str(yp)) for yt, yp in zip(y_true, y_pred))
+    total_len = sum(len(str(yt)) for yt in y_true)
+    if total_len == 0:
+        return 0.0
+    return float(_sigmoid(total_dist / total_len))
+
+
+def _strip_unit(val: str) -> str:
+    """숫자 값에서 단위/기호 제거: '6.12%' → '6.12', '175.09 g' → '175.09', '$1,234' → '1234'"""
+    s = str(val).strip()
+    s = s.replace(",", "")
+    s = s.strip("$€£¥₩%")
+    s = re.sub(r"\s*[a-zA-Z°]+\.?\s*$", "", s)
+    return s.strip()
+
+
+def _is_numeric(val) -> bool:
+    try:
+        float(_strip_unit(str(val)))
+        return True
+    except (ValueError, TypeError):
+        return False
+
+
+def _to_float_safe(val) -> float:
+    return float(_strip_unit(str(val)))
+
+
+def _score_series(gt_series: list, pred_series: list) -> float:
+    """
+    단일 컬럼(시리즈) 점수.
+    - 길이 불일치 → 0점
+    - GT가 숫자 → 단위 제거 후 RMSE
+    - GT가 문자열 → Levenshtein
+    """
+    if len(gt_series) != len(pred_series) or len(gt_series) == 0:
+        return 0.0
+
+    if all(_is_numeric(v) for v in gt_series if str(v).strip()):
+        try:
+            pred_nums = [_to_float_safe(x) for x in pred_series]
+        except (ValueError, TypeError):
+            return 0.0
+        gt_nums = [_to_float_safe(x) for x in gt_series]
+        return _normalized_rmse(gt_nums, pred_nums)
+    else:
+        return _normalized_levenshtein(
+            [str(x) for x in gt_series],
+            [str(x) for x in pred_series],
+        )
+
+
+# ---------------------------------------------------------------------------
+# 테이블 파서
+# ---------------------------------------------------------------------------
+
+
+def _parse_csv_to_columns(csv_string: str) -> list[list[str]]:
+    """CSV 문자열 → 컬럼별 리스트. columns[0]은 첫번째 컬럼 전체(헤더+데이터)."""
+    reader = csv.reader(io.StringIO(csv_string.strip()))
+    rows = [row for row in reader if any(cell.strip() for cell in row)]
+    if len(rows) < 2:
+        return []
+
+    num_cols = len(rows[0])
+    columns = []
+    for col_idx in range(num_cols):
+        col_data = [rows[row_idx][col_idx].strip() if col_idx < len(rows[row_idx]) else "" for row_idx in range(1, len(rows))]
+        columns.append(col_data)
+    return columns
+
+
+def _parse_markdown_table(md_string: str) -> list[list[str]]:
+    """마크다운 테이블 → 컬럼별 리스트. 구분선(---) 행은 건너뜀."""
+    md_string = md_string.strip()
+
+    # 코드 블록 안의 테이블 추출
+    code_block = re.search(r"```(?:markdown)?\s*\n(.*?)\n```", md_string, re.DOTALL)
+    if code_block:
+        md_string = code_block.group(1).strip()
+
+    lines = md_string.split("\n")
+    table_lines = []
+    for line in lines:
+        line = line.strip()
+        if not line or not "|" in line:
+            continue
+        # 구분선 행 건너뜀 (| --- | --- | 등)
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if all(re.match(r"^[-:]+$", c) for c in cells if c):
+            continue
+        table_lines.append(cells)
+
+    if len(table_lines) < 2:
+        return []
+
+    num_cols = len(table_lines[0])
+    columns = []
+    for col_idx in range(num_cols):
+        col_data = [table_lines[row_idx][col_idx].strip() if col_idx < len(table_lines[row_idx]) else "" for row_idx in range(1, len(table_lines))]
+        columns.append(col_data)
+    return columns
+
+
+# ---------------------------------------------------------------------------
+# Robust 메트릭용 행렬 파서 및 행 정렬
+# ---------------------------------------------------------------------------
+
+
+def _parse_csv_to_matrix(csv_string: str) -> list[list[str]]:
+    """CSV 문자열 → 전체 행렬 (헤더 포함). matrix[0]은 헤더 행."""
+    reader = csv.reader(io.StringIO(csv_string.strip()))
+    rows = [[cell.strip() for cell in row] for row in reader if any(cell.strip() for cell in row)]
+    return rows if len(rows) >= 2 else []
+
+
+def _parse_markdown_to_matrix(md_string: str) -> list[list[str]]:
+    """마크다운 테이블 → 전체 행렬 (헤더 포함). matrix[0]은 헤더 행."""
+    md_string = md_string.strip()
+    code_block = re.search(r"```(?:markdown)?\s*\n(.*?)\n```", md_string, re.DOTALL)
+    if code_block:
+        md_string = code_block.group(1).strip()
+
+    lines = md_string.split("\n")
+    table_lines = []
+    for line in lines:
+        line = line.strip()
+        if not line or "|" not in line:
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if all(re.match(r"^[-:]+$", c) for c in cells if c):
+            continue
+        table_lines.append(cells)
+    return table_lines if len(table_lines) >= 2 else []
+
+
+def _matrix_to_columns(matrix: list[list[str]]) -> list[list[str]]:
+    """행렬(헤더 포함)에서 데이터 컬럼 추출 (헤더 행 제외)."""
+    if len(matrix) < 2:
+        return []
+    num_cols = len(matrix[0])
+    columns = []
+    for col_idx in range(num_cols):
+        col_data = [matrix[row_idx][col_idx] if col_idx < len(matrix[row_idx]) else "" for row_idx in range(1, len(matrix))]
+        columns.append(col_data)
+    return columns
+
+
+def _transpose_full_matrix(matrix: list[list[str]]) -> list[list[str]]:
+    """헤더 포함 전체 행렬을 전치. [[H1,H2],[a,b],[c,d]] → [[H1,a,c],[H2,b,d]]"""
+    if not matrix:
+        return []
+    max_cols = max(len(row) for row in matrix)
+    transposed = []
+    for col_idx in range(max_cols):
+        new_row = [matrix[row_idx][col_idx] if col_idx < len(matrix[row_idx]) else "" for row_idx in range(len(matrix))]
+        transposed.append(new_row)
+    return transposed
+
+
+def _align_rows_by_label(gt_labels: list[str], pred_labels: list[str]) -> list[int]:
+    """
+    GT 라벨 기준으로 pred 행의 최적 매칭 인덱스를 반환 (greedy, 유사도 내림차순).
+    alignment[i] = pred 행 인덱스 (-1이면 미매칭).
+    """
+    n_gt = len(gt_labels)
+    n_pred = len(pred_labels)
+    if n_gt == 0 or n_pred == 0:
+        return [-1] * n_gt
+
+    pairs = []
+    for gi, gl in enumerate(gt_labels):
+        gt_str = str(gl).strip()
+        for pi, pl in enumerate(pred_labels):
+            pred_str = str(pl).strip()
+            max_len = max(len(gt_str), len(pred_str), 1)
+            sim = 1.0 - levenshtein_distance(gt_str, pred_str) / max_len
+            pairs.append((sim, gi, pi))
+
+    pairs.sort(key=lambda x: x[0], reverse=True)
+
+    alignment = [-1] * n_gt
+    used_pred: set[int] = set()
+    for sim, gi, pi in pairs:
+        if alignment[gi] != -1 or pi in used_pred:
+            continue
+        if sim >= 0.3:
+            alignment[gi] = pi
+            used_pred.add(pi)
+    return alignment
+
+
+def _score_table_robust(gt_columns: list[list[str]], pred_columns: list[list[str]]) -> tuple[float, float, float]:
+    """
+    Robust 스코어링: 라벨 기반 행 정렬 후 매칭된 행만 채점.
+    미매칭 행은 coverage 비율로 감점 (0.75 매칭 → 점수 × 0.75).
+    """
+    if not gt_columns or not pred_columns:
+        return 0.0, 0.0, 0.0
+
+    n_gt_rows = len(gt_columns[0])
+    n_pred_rows = len(pred_columns[0]) if pred_columns else 0
+    if n_gt_rows == 0 or n_pred_rows == 0:
+        return 0.0, 0.0, 0.0
+
+    while len(pred_columns) < len(gt_columns):
+        pred_columns.append([""] * n_pred_rows)
+    pred_columns = pred_columns[: len(gt_columns)]
+
+    alignment = _align_rows_by_label(gt_columns[0], pred_columns[0])
+    matched_gt_indices = [i for i, a in enumerate(alignment) if a != -1]
+
+    if not matched_gt_indices:
+        return 0.0, 0.0, 0.0
+
+    coverage = len(matched_gt_indices) / n_gt_rows
+
+    aligned_gt_columns = []
+    aligned_pred_columns = []
+    for col_idx in range(len(gt_columns)):
+        gt_col = [gt_columns[col_idx][i] for i in matched_gt_indices]
+        pred_col = [pred_columns[col_idx][alignment[i]] for i in matched_gt_indices]
+        aligned_gt_columns.append(gt_col)
+        aligned_pred_columns.append(pred_col)
+
+    label_score = _score_series(aligned_gt_columns[0], aligned_pred_columns[0])
+
+    value_scores = []
+    for i in range(1, len(aligned_gt_columns)):
+        score = _score_series(aligned_gt_columns[i], aligned_pred_columns[i])
+        value_scores.append(score)
+
+    avg_value = float(np.mean(value_scores)) if value_scores else 0.0
+    all_scores = [label_score] + value_scores
+    raw_overall = float(np.mean(all_scores))
+
+    return raw_overall * coverage, label_score * coverage, avg_value * coverage
+
+
+# ---------------------------------------------------------------------------
+# lmms-eval 태스크 인터페이스
+# ---------------------------------------------------------------------------
+
+
+def chartqa_parsing_doc_to_visual(doc):
+    return [doc["image"].convert("RGB")]
+
+
+def chartqa_parsing_doc_to_text(doc, lmms_eval_specific_kwargs):
+    post_prompt = lmms_eval_specific_kwargs.get("post_prompt", "Extract all data from this chart as a markdown table.")
+    pre_prompt = lmms_eval_specific_kwargs.get("pre_prompt", "")
+    return f"{pre_prompt}{post_prompt}"
+
+
+def _transpose_columns(columns: list[list[str]]) -> list[list[str]]:
+    """컬럼 리스트를 전치(transpose). [[a,b],[c,d]] → [[a,c],[b,d]]"""
+    if not columns or not columns[0]:
+        return columns
+    n_rows = len(columns[0])
+    n_cols = len(columns)
+    transposed = []
+    for r in range(n_rows):
+        transposed.append([columns[c][r] if r < len(columns[c]) else "" for c in range(n_cols)])
+    return transposed
+
+
+def _score_table(gt_columns, pred_columns):
+    """GT와 예측 컬럼을 비교해서 (overall, label, value) 점수 반환."""
+    if not gt_columns or not pred_columns:
+        return 0.0, 0.0, 0.0
+
+    while len(pred_columns) < len(gt_columns):
+        pred_columns.append([])
+    pred_columns = pred_columns[: len(gt_columns)]
+
+    label_score = _score_series(gt_columns[0], pred_columns[0])
+
+    value_scores = []
+    for i in range(1, len(gt_columns)):
+        score = _score_series(gt_columns[i], pred_columns[i])
+        value_scores.append(score)
+
+    avg_value = float(np.mean(value_scores)) if value_scores else 0.0
+    all_scores = [label_score] + value_scores
+    overall = float(np.mean(all_scores))
+    return overall, label_score, avg_value
+
+
+def chartqa_parsing_process_results(doc, results):
+    pred = results[0]
+    gt_csv = doc["table_csv"]
+
+    gt_columns = _parse_csv_to_columns(gt_csv)
+    pred_columns = _parse_markdown_table(pred)
+
+    zero_result = {"parsing_overall": 0.0, "parsing_label": 0.0, "parsing_value": 0.0, "robust_overall": 0.0, "robust_label": 0.0, "robust_value": 0.0}
+
+    if not gt_columns or not pred_columns:
+        return zero_result
+
+    # --- Strict 메트릭 (기존): 위치 기반 비교 ---
+    overall, label_score, avg_value = _score_table(gt_columns, pred_columns)
+
+    if len(pred_columns) >= 2 and len(pred_columns[0]) >= 2:
+        transposed = _transpose_columns(pred_columns)
+        t_overall, t_label, t_value = _score_table(gt_columns, transposed)
+        if t_overall > overall:
+            overall, label_score, avg_value = t_overall, t_label, t_value
+
+    # --- Robust 메트릭: 라벨 기반 행 정렬 + 헤더 포함 full transpose ---
+    gt_matrix = _parse_csv_to_matrix(gt_csv)
+    pred_matrix = _parse_markdown_to_matrix(pred)
+
+    if not gt_matrix or not pred_matrix:
+        r_overall, r_label, r_value = 0.0, 0.0, 0.0
+    else:
+        gt_cols_r = _matrix_to_columns(gt_matrix)
+        pred_cols_orig = _matrix_to_columns(pred_matrix)
+        r_overall, r_label, r_value = _score_table_robust(gt_cols_r, pred_cols_orig)
+
+        pred_matrix_t = _transpose_full_matrix(pred_matrix)
+        pred_cols_t = _matrix_to_columns(pred_matrix_t)
+        if pred_cols_t:
+            rt_overall, rt_label, rt_value = _score_table_robust(gt_cols_r, pred_cols_t)
+            if rt_overall > r_overall:
+                r_overall, r_label, r_value = rt_overall, rt_label, rt_value
+
+    return {
+        "parsing_overall": overall,
+        "parsing_label": label_score,
+        "parsing_value": avg_value,
+        "robust_overall": r_overall,
+        "robust_label": r_label,
+        "robust_value": r_value,
+    }


### PR DESCRIPTION
## Summary

- **ChartQA Parsing** 태스크 추가: ChartQA 데이터셋의 차트 이미지에서 테이블 데이터 추출 성능을 평가. Strict(위치 기반) 및 Robust(라벨 정렬 기반) 두 가지 메트릭 체계를 제공하여 구조 충실도와 데이터 추출 정확도를 각각 측정.
- **Benetech Parsing** 태스크 추가: Kaggle "Making Graphs Accessible" 대회의 공식 메트릭(sigmoid-scaled R², Levenshtein)을 lmms-eval로 이식. extracted 서브셋 1,118개 샘플로 차트 이미지 → JSON 데이터 시리즈 추출 능력 평가.
- `.gitignore`에 `results/` 디렉토리 추가.

## Details

### ChartQA Parsing Metrics
| Metric | Type | Description |
|--------|------|-------------|
| `parsing_overall/label/value` | Strict | 위치 기반 행 비교, 구조 완전 일치 기준 |
| `robust_overall/label/value` | Robust | Levenshtein 유사도 기반 행 정렬, coverage 감점 |

### Benetech Parsing Metrics
| Metric | Description |
|--------|-------------|
| `benetech_overall` | x, y 시리즈 점수 평균 |
| `benetech_ocr` | 문자열 시리즈 (Levenshtein 기반) |
| `benetech_value` | 숫자 시리즈 (R² 기반) |
| `benetech_type_acc` | chart type 분류 정확도 |

## Test plan
- [ ] ChartQA parsing 태스크 `--limit 5`로 실행 확인
- [ ] Benetech parsing 태스크 `--limit 5`로 실행 확인
- [ ] 메트릭 값이 0~1 범위 내 정상 출력 확인


Made with [Cursor](https://cursor.com)